### PR TITLE
Make LineNumberStyle props public, init method

### DIFF
--- a/Sources/SavannaKit/Model/SyntaxColorTheme.swift
+++ b/Sources/SavannaKit/Model/SyntaxColorTheme.swift
@@ -10,9 +10,14 @@ import Foundation
 
 public struct LineNumbersStyle {
 	
-	let font: Font
-	let textColor: Color
+	public let font: Font
+	public let textColor: Color
 	
+	public init(font: Font, textColor: Color) {
+		self.font = font
+		self.textColor = textColor
+	}
+
 }
 
 public protocol SyntaxColorTheme {


### PR DESCRIPTION
From my understanding of the `SyntaxColorTheme` protocol, an implementor needs to return a `lineNumbersStyle` of type `LineNumbersStyle` but there isn't a public initializer method.