### PR TITLE
Make SyntaxTextView.init(frame:) public

### DIFF
--- a/Sources/SavannaKit/View/SyntaxTextView.swift
+++ b/Sources/SavannaKit/View/SyntaxTextView.swift
@@ -89,7 +89,7 @@ public class SyntaxTextView: View {
 	
 	#endif
 	
-	override convenience init(frame: CGRect) {
+	public override convenience init(frame: CGRect) {
 		self.init(.frame(frame))!
 	}
 	


### PR DESCRIPTION
From my understanding of `SyntaxTextView`, this init method should be public.