### PR TITLE
Uses Range<String.Index>

### DIFF
--- a/Sources/SavannaKit/Model/Token.swift
+++ b/Sources/SavannaKit/Model/Token.swift
@@ -12,7 +12,7 @@ public protocol Token {
 	
 	var savannaTokenType: TokenType { get }
 	
-	var range: Range<Int>? { get }
+	var range: Range<String.Index>? { get }
 	
 }
 

--- a/Sources/SavannaKit/Util/String+Range.swift
+++ b/Sources/SavannaKit/Util/String+Range.swift
@@ -24,19 +24,5 @@ extension String {
 		
 		return NSRange(location: utf16.distance(from: utf16.startIndex, to: start), length: utf16.distance(from: start, to: end))
 	}
-	
-//    func nsRange(fromRange range: Range<Int>) -> NSRange? {
-//        
-//        guard range.upperBound <= self.count else {
-//            return nil
-//        }
-//        
-//        let start = self.index(startIndex, offsetBy: range.lowerBound)
-//        let end = self.index(startIndex, offsetBy: range.upperBound)
-//
-//        let indexRange = start..<end
-//        
-//        return nsRange(fromRange: indexRange)
-//    }
 
 }

--- a/Sources/SavannaKit/Util/String+Range.swift
+++ b/Sources/SavannaKit/Util/String+Range.swift
@@ -25,18 +25,18 @@ extension String {
 		return NSRange(location: utf16.distance(from: utf16.startIndex, to: start), length: utf16.distance(from: start, to: end))
 	}
 	
-	func nsRange(fromRange range: Range<Int>) -> NSRange? {
-		
-		guard range.upperBound <= self.count else {
-			return nil
-		}
-		
-		let start = self.index(startIndex, offsetBy: range.lowerBound)
-		let end = self.index(startIndex, offsetBy: range.upperBound)
-
-		let indexRange = start..<end
-		
-		return nsRange(fromRange: indexRange)
-	}
+//    func nsRange(fromRange range: Range<Int>) -> NSRange? {
+//        
+//        guard range.upperBound <= self.count else {
+//            return nil
+//        }
+//        
+//        let start = self.index(startIndex, offsetBy: range.lowerBound)
+//        let end = self.index(startIndex, offsetBy: range.upperBound)
+//
+//        let indexRange = start..<end
+//        
+//        return nsRange(fromRange: indexRange)
+//    }
 
 }


### PR DESCRIPTION
I've changed the Token to return a Range<String.Index> rather than Range<Int> as discussed in #6.