### PR TITLE
Provides public designated initializer

### DIFF
--- a/Sources/SavannaKit/View/SyntaxTextView.swift
+++ b/Sources/SavannaKit/View/SyntaxTextView.swift
@@ -15,11 +15,6 @@ import CoreGraphics
 	import UIKit
 #endif
 
-private enum InitMethod {
-	case coder(NSCoder)
-	case frame(CGRect)
-}
-
 public protocol SyntaxTextViewDelegate: class {
 	
 	func didChangeText(_ syntaxTextView: SyntaxTextView)
@@ -90,35 +85,31 @@ open class SyntaxTextView: View {
 	}
 	
 	#endif
+    
+    public override init(frame: CGRect) {
+        textView = SyntaxTextView.createInnerTextView()
+        super.init(frame: frame)
+        setup()
+    }
+    
+    public required init?(coder aDecoder: NSCoder) {
+        textView = SyntaxTextView.createInnerTextView()
+        super.init(coder: aDecoder)
+        setup()
+    }
 	
-	public override convenience init(frame: CGRect) {
-		self.init(.frame(frame))!
-	}
-	
-	public required convenience init?(coder aDecoder: NSCoder) {
-		self.init(.coder(aDecoder))
-	}
-	
-	private init?(_ initMethod: InitMethod) {
-		
-		let textStorage = NSTextStorage()
-		let layoutManager = SyntaxTextViewLayoutManager()
-		let containerSize = CGSize(width: 0, height: CGFloat.greatestFiniteMagnitude)
-		let textContainer = NSTextContainer(size: containerSize)
-		
-		textContainer.widthTracksTextView = true
-		layoutManager.addTextContainer(textContainer)
-		textStorage.addLayoutManager(layoutManager)
-		
-		self.textView = InnerTextView(frame: .zero, textContainer: textContainer)
-		
-		switch initMethod {
-		case let .coder(coder): super.init(coder: coder)
-		case let .frame(frame): super.init(frame: frame)
-		}
-		
-		setup()
-	}
+    private static func createInnerTextView() -> InnerTextView {
+        let textStorage = NSTextStorage()
+        let layoutManager = SyntaxTextViewLayoutManager()
+        let containerSize = CGSize(width: 0, height: CGFloat.greatestFiniteMagnitude)
+        let textContainer = NSTextContainer(size: containerSize)
+        
+        textContainer.widthTracksTextView = true
+        layoutManager.addTextContainer(textContainer)
+        textStorage.addLayoutManager(layoutManager)
+        
+        return InnerTextView(frame: .zero, textContainer: textContainer)
+    }
 
 	#if os(macOS)
 


### PR DESCRIPTION
As a response to #8, the SyntaxTextView was made open in b67a5117c75d904f1b0bb802cdc9682435a8b3b3 but the SyntaxTextView is lacking a public designated initializer that can be called when implementing an initializer.
To address this, I've gotten rid of the `InitMethod` and introduced `createInnerTextView()` to perform most of the common work. 
As a result the two initializers `init(frame:)` and `init(coder:)` can be overriden and called by subclasses.