### PR TITLE
Allows app extension API only

### DIFF
--- a/SavannaKit.xcodeproj/project.pbxproj
+++ b/SavannaKit.xcodeproj/project.pbxproj
@@ -427,6 +427,7 @@
 		BE1562741EFE9E7C00EB3723 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_STYLE = Manual;
@@ -455,6 +456,7 @@
 		BE1562751EFE9E7C00EB3723 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_STYLE = Manual;
@@ -602,6 +604,7 @@
 		BEDA3F3E1E380E5D00B5091C /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CODE_SIGN_IDENTITY = "";
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEFINES_MODULE = YES;
@@ -629,6 +632,7 @@
 		BEDA3F3F1E380E5D00B5091C /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CODE_SIGN_IDENTITY = "";
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = "";


### PR DESCRIPTION
As of now, there seems to be no reason why `APPLICATION_EXTENSION_API_ONLY` should be set to true. I'm using the SavannaKit in an app extension and would like to avoid the error Xcode gives.