### PR TITLE
Updates appearance when setting theme

### DIFF
--- a/Sources/SavannaKit/View/SyntaxTextView.swift
+++ b/Sources/SavannaKit/View/SyntaxTextView.swift
@@ -358,6 +358,8 @@ open class SyntaxTextView: View {
 	public var theme: SyntaxColorTheme = DefaultTheme() {
 		didSet {
 			cachedThemeInfo = nil
+            backgroundColor = theme.backgroundColor
+            textView.backgroundColor = theme.backgroundColor
 		}
 	}
 	

--- a/Sources/SavannaKit/View/SyntaxTextView.swift
+++ b/Sources/SavannaKit/View/SyntaxTextView.swift
@@ -360,6 +360,7 @@ open class SyntaxTextView: View {
 			cachedThemeInfo = nil
             backgroundColor = theme.backgroundColor
             textView.backgroundColor = theme.backgroundColor
+            textView.theme = theme
 		}
 	}
 	

--- a/Sources/SavannaKit/View/SyntaxTextView.swift
+++ b/Sources/SavannaKit/View/SyntaxTextView.swift
@@ -358,7 +358,9 @@ open class SyntaxTextView: View {
 	public var theme: SyntaxColorTheme = DefaultTheme() {
 		didSet {
 			cachedThemeInfo = nil
+            #if os(iOS)
             backgroundColor = theme.backgroundColor
+            #endif
             textView.backgroundColor = theme.backgroundColor
             textView.theme = theme
 		}


### PR DESCRIPTION
Fixes an issue where the background color of the SyntaxTextView and its inner text view was not updated when setting the theme. Also forwards the theme to the inner text view so the colors of the line numbers in the gutter are correctly updated.