### PR TITLE
Exposes adjustsFontForContentSizeCategory

### DIFF
--- a/Sources/SavannaKit/View/SyntaxTextView.swift
+++ b/Sources/SavannaKit/View/SyntaxTextView.swift
@@ -60,6 +60,11 @@ open class SyntaxTextView: View {
 	
 	#if os(iOS)
 
+    public var adjustsFontForContentSizeCategory: Bool {
+        get { return contentTextView.adjustsFontForContentSizeCategory }
+        set { contentTextView.adjustsFontForContentSizeCategory = newValue }
+    }
+    
 	public var contentInset: UIEdgeInsets = .zero {
 		didSet {
 			textView.contentInset = contentInset


### PR DESCRIPTION
Exposes `adjustsFontForContentSizeCategory` on the SyntaxTextView. The property just "proxies" to the contentTextView which is internal.