### PR TITLE
Fixes placement of line numbers

### DIFF
--- a/Sources/SavannaKit/View/InnerTextView.swift
+++ b/Sources/SavannaKit/View/InnerTextView.swift
@@ -86,19 +86,6 @@ class InnerTextView: TextView {
 			
 		} else {
 			
-			var paragraphs: [Paragraph]
-			
-			if let cached = textView.cachedParagraphs {
-				
-				paragraphs = cached
-				
-			} else {
-				
-				paragraphs = generateParagraphs(for: textView, flipRects: false)
-				textView.cachedParagraphs = paragraphs
-				
-			}
-			
 			let components = textView.text.components(separatedBy: .newlines)
 			
 			let count = components.count
@@ -106,6 +93,19 @@ class InnerTextView: TextView {
 			let maxNumberOfDigits = "\(count)".count
 			
 			textView.updateGutterWidth(for: maxNumberOfDigits)
+            
+            var paragraphs: [Paragraph]
+            
+            if let cached = textView.cachedParagraphs {
+                
+                paragraphs = cached
+                
+            } else {
+                
+                paragraphs = generateParagraphs(for: textView, flipRects: false)
+                textView.cachedParagraphs = paragraphs
+                
+            }
 			
 			theme.gutterStyle.backgroundColor.setFill()
 			


### PR DESCRIPTION
Fixes a bug where the line numbers would sometimes be incorrectly placed when editing a text that contains a wrapped line.

Updating the gutter width updates the textContainerInset, practically reducing the size available for laying out text. Because the paragraphs were generated before updating the gutter width, the line numbers would be incorrectly placed if the updated gutter width causes a line to be wrapped.
To address the issue, I've ensured that paragraphs aren't generated before the gutter width is updated.