### PR TITLE
Add a new delegate method to handle editing, and provide default implementations of optional SyntaxTextViewDelegate methods

### DIFF
--- a/Sources/SavannaKit/View/SyntaxTextView+TextViewDelegate.swift
+++ b/Sources/SavannaKit/View/SyntaxTextView+TextViewDelegate.swift
@@ -194,6 +194,11 @@ extension SyntaxTextView {
 			return self.shouldChangeText(insertingText: text)
 		}
 		
+		public func textViewDidBeginEditing(_ textView: UITextView) {
+			// pass the message up to our own delegate
+			delegate?.textViewDidBeginEditing(self)
+		}
+		
 		open func textViewDidChange(_ textView: UITextView) {
 			
 			didUpdateText()

--- a/Sources/SavannaKit/View/SyntaxTextView.swift
+++ b/Sources/SavannaKit/View/SyntaxTextView.swift
@@ -21,8 +21,19 @@ public protocol SyntaxTextViewDelegate: class {
 
 	func didChangeSelectedRange(_ syntaxTextView: SyntaxTextView, selectedRange: NSRange)
 	
+	func textViewDidBeginEditing(_ syntaxTextView: SyntaxTextView)
+	
 	func lexerForSource(_ source: String) -> Lexer
 	
+}
+
+// Provide default empty implementations of methods that are optional.
+public extension SyntaxTextViewDelegate {
+    func didChangeText(_ syntaxTextView: SyntaxTextView) { }
+	
+    func didChangeSelectedRange(_ syntaxTextView: SyntaxTextView, selectedRange: NSRange) { }
+	
+    func textViewDidBeginEditing(_ syntaxTextView: SyntaxTextView) { }
 }
 
 struct ThemeInfo {


### PR DESCRIPTION
Making a type conform to `SyntaxTextViewDelegate` means implementing `didChangeText()`, `didChangeSelectedRange()`, and `lexerForSource()`, but only the last of those is actually required – a lot of code (including Louis's Source Editor sample code) just provide empty implementations of the first two. So, this code does that automatically so that conforming types now need to implement only the methods they want.

This PR also adds a new delegate method (again with a default empty implementation), called `textViewDidBeginEditing()`. This is triggered when the internal text view starts editing, so it just passes the message on upwards so it can be handled appropriately.