### PR TITLE
Swift 4.2 syntax

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode9.3
+osx_image: xcode10
 branches:
   only:
     - master

--- a/SavannaKit.xcodeproj/project.pbxproj
+++ b/SavannaKit.xcodeproj/project.pbxproj
@@ -577,7 +577,7 @@
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Debug;
 		};
@@ -606,7 +606,7 @@
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Release;
 		};
@@ -753,7 +753,7 @@
 				PRODUCT_NAME = SavannaKit;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Debug;
 		};
@@ -780,7 +780,7 @@
 				PRODUCT_NAME = SavannaKit;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Release;
 		};
@@ -803,7 +803,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = be.silverfox.SavannaKitTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Debug;
 		};
@@ -826,7 +826,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = be.silverfox.SavannaKitTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Release;
 		};
@@ -848,7 +848,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "be.silverfox.savannakit.iOS-Example";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -871,7 +871,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "be.silverfox.savannakit.iOS-Example";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;

--- a/Sources/SavannaKit/Model/Paragraph.swift
+++ b/Sources/SavannaKit/Model/Paragraph.swift
@@ -29,7 +29,7 @@ struct Paragraph {
 		let attr = NSMutableAttributedString(string: string)
 		let range = NSMakeRange(0, attr.length)
 		
-		let attributes: [NSAttributedStringKey: Any] = [
+		let attributes: [NSAttributedString.Key: Any] = [
 			.font: style.font,
 			.foregroundColor : style.textColor
 		]

--- a/Sources/SavannaKit/Model/SyntaxColorTheme.swift
+++ b/Sources/SavannaKit/Model/SyntaxColorTheme.swift
@@ -47,7 +47,7 @@ public protocol SyntaxColorTheme {
 	
 	var backgroundColor: Color { get }
 
-	func globalAttributes() -> [NSAttributedStringKey: Any]
+	func globalAttributes() -> [NSAttributedString.Key: Any]
 
-	func attributes(for token: Token) -> [NSAttributedStringKey: Any]
+	func attributes(for token: Token) -> [NSAttributedString.Key: Any]
 }

--- a/Sources/SavannaKit/Util/NSMutableAttributedString+Tokens.swift
+++ b/Sources/SavannaKit/Util/NSMutableAttributedString+Tokens.swift
@@ -20,7 +20,7 @@ public extension NSMutableAttributedString {
 		
 		self.init(string: source)
 		
-		var attributes = [NSAttributedStringKey: Any]()
+        var attributes = [NSAttributedString.Key: Any]()
 		
 		let spaceAttrString = NSAttributedString(string: " ", attributes: [.font: theme.font])
 		let spaceWidth = spaceAttrString.size().width
@@ -63,7 +63,7 @@ public extension NSMutableAttributedString {
 				
 				let contentRange = NSRange(location: range.lowerBound + 2, length: range.length - 4)
 				
-				var attr = [NSAttributedStringKey: Any]()
+                var attr = [NSAttributedString.Key: Any]()
 				
 				attr[.editorPlaceholder] = EditorPlaceholderState.inactive
 				

--- a/Sources/SavannaKit/View/LineNumberLayoutManager.swift
+++ b/Sources/SavannaKit/View/LineNumberLayoutManager.swift
@@ -64,16 +64,28 @@ class LineNumberLayoutManager: NSLayoutManager {
 		}
 	}
 	
-	override func processEditing(for textStorage: NSTextStorage, edited editMask: NSTextStorageEditActions, range newCharRange: NSRange, changeInLength delta: Int, invalidatedRange invalidatedCharRange: NSRange) {
-		super.processEditing(for: textStorage, edited: editMask, range: newCharRange, changeInLength: delta, invalidatedRange: invalidatedCharRange)
-		if invalidatedCharRange.location < lastParaLocation {
-			//  When the backing store is edited ahead the cached paragraph location, invalidate the cache and force a complete
-			//  recalculation.  We cannot be much smarter than this because we don't know how many paragraphs have been deleted
-			//  since the text has already been removed from the backing store.
-			lastParaLocation = 0
-			lastParaNumber = 0
-		}
-	}
+    #if os(macOS)
+    override func processEditing(for textStorage: NSTextStorage, edited editMask:NSTextStorageEditActions, range newCharRange: NSRange, changeInLength delta: Int, invalidatedRange invalidatedCharRange: NSRange) {
+        super.processEditing(for: textStorage, edited: editMask, range: newCharRange, changeInLength: delta, invalidatedRange: invalidatedCharRange)
+        processEditing(invalidatedCharRange: invalidatedCharRange)
+    }
+    #else
+    override func processEditing(for textStorage: NSTextStorage, edited editMask:NSTextStorage.EditActions, range newCharRange: NSRange, changeInLength delta: Int, invalidatedRange invalidatedCharRange: NSRange) {
+        super.processEditing(for: textStorage, edited: editMask, range: newCharRange, changeInLength: delta, invalidatedRange: invalidatedCharRange)
+        processEditing(invalidatedCharRange: invalidatedCharRange)
+    }
+    #endif
+    
+    func processEditing(invalidatedCharRange: NSRange) {
+        if invalidatedCharRange.location < lastParaLocation {
+            //  When the backing store is edited ahead the cached paragraph location, invalidate the cache and force a complete
+            //  recalculation.  We cannot be much smarter than this because we don't know how many paragraphs have been deleted
+            //  since the text has already been removed from the backing store.
+            lastParaLocation = 0
+            lastParaNumber = 0
+        }
+    }
+    
 	
 	var gutterWidth: CGFloat = 0.0
 	
@@ -84,7 +96,7 @@ class LineNumberLayoutManager: NSLayoutManager {
 		
 //		let style = DefaultTheme().lineNumbersStyle!
 		
-		let atts: [NSAttributedStringKey: Any] = [:
+        let atts: [NSAttributedString.Key: Any] = [:
 //			.font: style.font,
 //			.foregroundColor : style.textColor
 		]

--- a/Sources/SavannaKit/View/SyntaxTextView.swift
+++ b/Sources/SavannaKit/View/SyntaxTextView.swift
@@ -466,7 +466,7 @@ open class SyntaxTextView: View {
 		
 		for (range, state) in rangesToUpdate {
 			
-			var attr = [NSAttributedStringKey: Any]()
+			var attr = [NSAttributedString.Key: Any]()
 			attr[.editorPlaceholder] = state
 
 			textStorage.addAttributes(attr, range: range)
@@ -483,7 +483,7 @@ open class SyntaxTextView: View {
 		
 		textStorage.beginEditing()
 
-		var attributes = [NSAttributedStringKey: Any]()
+		var attributes = [NSAttributedString.Key: Any]()
 		
 		let paragraphStyle = NSMutableParagraphStyle()
 		paragraphStyle.paragraphSpacing = 2.0
@@ -521,7 +521,7 @@ open class SyntaxTextView: View {
 				
 				let contentRange = NSRange(location: range.lowerBound + 2, length: range.length - 4)
 				
-				var attr = [NSAttributedStringKey: Any]()
+				var attr = [NSAttributedString.Key: Any]()
 				
 				var state: EditorPlaceholderState = .inactive
 				

--- a/Sources/SavannaKit/View/SyntaxTextViewLayoutManager.swift
+++ b/Sources/SavannaKit/View/SyntaxTextViewLayoutManager.swift
@@ -20,9 +20,9 @@ public enum EditorPlaceholderState {
 	case inactive
 }
 
-public extension NSAttributedStringKey {
+public extension NSAttributedString.Key {
 	
-	static public let editorPlaceholder = NSAttributedStringKey("editorPlaceholder")
+	static public let editorPlaceholder = NSAttributedString.Key("editorPlaceholder")
 
 }
 

--- a/iOS Example/AppDelegate.swift
+++ b/iOS Example/AppDelegate.swift
@@ -14,7 +14,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 	var window: UIWindow?
 
 
-	func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
 		// Override point for customization after application launch.
 		return true
 	}

--- a/iOS Example/ViewController.swift
+++ b/iOS Example/ViewController.swift
@@ -113,9 +113,9 @@ class MyTheme: SyntaxColorTheme {
 	
 	let backgroundColor = Color(red: 31/255.0, green: 32/255, blue: 41/255, alpha: 1.0)
 	
-	func globalAttributes() -> [NSAttributedStringKey: Any] {
+    func globalAttributes() -> [NSAttributedString.Key: Any] {
 		
-		var attributes = [NSAttributedStringKey: Any]()
+        var attributes = [NSAttributedString.Key: Any]()
 
 		attributes[.font] = Font(name: "Menlo", size: 15)!
 		attributes[.foregroundColor] = UIColor.white
@@ -123,13 +123,13 @@ class MyTheme: SyntaxColorTheme {
 		return attributes
 	}
 	
-	func attributes(for token: Token) -> [NSAttributedStringKey: Any] {
+    func attributes(for token: Token) -> [NSAttributedString.Key: Any] {
 		
 		guard let myToken = token as? MyToken else {
 			return [:]
 		}
 		
-		var attributes = [NSAttributedStringKey: Any]()
+        var attributes = [NSAttributedString.Key: Any]()
 		
 		switch myToken.type {
 		case .longWord:


### PR DESCRIPTION
Tried to convert to Swift 4.2 syntax. This is a bit scary since there are no tests, but most of the changes are just renaming things, so should be ok. The only part where I had to refactor a bit more is the following:

`processEditing` was using `NSTextStorageEditActions` for both platforms, like so:

```
override func processEditing(for textStorage: NSTextStorage, edited editMask: NSTextStorageEditActions, range newCharRange: NSRange, changeInLength delta: Int, invalidatedRange invalidatedCharRange: NSRange) {
	super.processEditing(for: textStorage, edited: editMask, range: newCharRange, changeInLength: delta, invalidatedRange: invalidatedCharRange)
	if invalidatedCharRange.location < lastParaLocation {
		//  When the backing store is edited ahead the cached paragraph location, invalidate the cache and force a complete
		//  recalculation.  We cannot be much smarter than this because we don't know how many paragraphs have been deleted
		//  since the text has already been removed from the backing store.
		lastParaLocation = 0
		lastParaNumber = 0
	}
}
```

However, it seems that in 4.2 it was renamed to `NSTextStorage.EditActions` on iOS platform, but not on macOS. So I decided to refactor it like this:

```
#if os(macOS)
override func processEditing(for textStorage: NSTextStorage, edited editMask:NSTextStorageEditActions, range newCharRange: NSRange, changeInLength delta: Int, invalidatedRange invalidatedCharRange: NSRange) {
    super.processEditing(for: textStorage, edited: editMask, range: newCharRange, changeInLength: delta, invalidatedRange: invalidatedCharRange)
    processEditing(invalidatedCharRange: invalidatedCharRange)
}
#else
override func processEditing(for textStorage: NSTextStorage, edited editMask:NSTextStorage.EditActions, range newCharRange: NSRange, changeInLength delta: Int, invalidatedRange invalidatedCharRange: NSRange) {
    super.processEditing(for: textStorage, edited: editMask, range: newCharRange, changeInLength: delta, invalidatedRange: invalidatedCharRange)
    processEditing(invalidatedCharRange: invalidatedCharRange)
}
#endif

func processEditing(invalidatedCharRange: NSRange) {
    if invalidatedCharRange.location < lastParaLocation {
        //  When the backing store is edited ahead the cached paragraph location, invalidate the cache and force a complete
        //  recalculation.  We cannot be much smarter than this because we don't know how many paragraphs have been deleted
        //  since the text has already been removed from the backing store.
        lastParaLocation = 0
        lastParaNumber = 0
    }
}
```

Hopefully this makes sense.